### PR TITLE
Fixed AttributeError when parameterizing fixtures

### DIFF
--- a/UniqueFixturesNames/__init__.py
+++ b/UniqueFixturesNames/__init__.py
@@ -50,7 +50,7 @@ class UniqueFixturesNames(object):
                     if not hasattr(deco, "func"):
                         continue
 
-                    if deco.func.value.id == "pytest" and deco.func.attr == "fixture":
+                    if deco.func.attr == "fixture" and deco.func.value.id == "pytest":
                         name = func.name
                         if name not in FIXTURES:
                             FIXTURES.append(name)


### PR DESCRIPTION
Using the @pytest.mark.parametrize decorator on fixtures caused an AttributeError when evaluating the decorator. Changing the order in which the conditions are checked remedies this issues.

The code has been verified to work with parametrized fixtures, no change to the plugin's functionality.