### PR TITLE
Update tox.ini test commands

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ deps =
     pytest
     flake8
 commands =
-    python setup.py install
-    pytest -s --basetemp=tmp PolarionIds/tests
+    python3 -m pip install .
+    pytest -s PolarionIds/tests
 
 [flake8]
 [testenv:code-check]
@@ -34,5 +34,5 @@ deps=
     flake8
 
 commands =
-    python setup.py install
-    pytest -s --basetemp=tmp PolarionIds/tests
+    python3 -m pip install .
+    pytest -s PolarionIds/tests


### PR DESCRIPTION
Replace deprecated setup.py install with pip install and remove basetemp option from pytest. This modernizes the test execution to use standard pip installation and simplifies pytest configuration by removing the unnecessary temporary directory specification.